### PR TITLE
Smartlook fix

### DIFF
--- a/Dockerfile_Deploy
+++ b/Dockerfile_Deploy
@@ -17,6 +17,7 @@ COPY . .
 
 # Set environmental variable
 ARG VUE_APP_API_URL=https://api.padma.io
+ARG VUE_APP_SMARTLOOK_KEY=c270bc61269cadec125852dcbb96e50b470d6c99
 
 # build app for production with minification
 RUN yarn build

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,7 +23,9 @@ export default {
       this.$store.commit("storeDicOptions", optionsData);
     }
 
-    smartlookClient.init(process.env.SL_KEY);
+    if (process.env.NODE_ENV === "production") {
+      smartlookClient.init(process.env.SMARTLOOK_KEY);
+    }
   }
 };
 </script>


### PR DESCRIPTION
1. Docker deploy for prod build uses the smartlook key now
2. App.vue ensures smartlook isnt loaded except in production
